### PR TITLE
Expand honeypot with additional fake services

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,17 @@ Simple low-interactive honeypot in C intended to trick scanners such as nmap by 
 - Cisco telnetd (IOS 6.X)
 - Cisco ASA firewall http config
 - Cisco CallManager license manager 6
+- Cisco SCCP (Skinny)
+- Cisco Smart Install client
+- Cisco SIP gateway
+- Cisco TFTP server
+- Cisco SNMP agent
+- Cisco VPN 3000 concentrator
+- Microsoft Active Directory LDAP GC
+- Microsoft Windows RPC
+- Apple ARD agent
+- Apple iTunes DAAP sharing
+- IBM MessageSight MQTT over TLS
+- VMware VAMI
 - Oracle Application Server 11g httpd
 - Oracle Database Lite RMI

--- a/src/connection.c
+++ b/src/connection.c
@@ -21,8 +21,8 @@
  */
 
 // External config variables
-int var_debug;
-char *var_type;
+extern int var_debug;
+extern char *var_type;
 
 
 void cisco_telnet_fire1_banner(int sock)
@@ -57,7 +57,69 @@ void oracle_app_manager_banner(int sock)
 
 void oracle_rmi_lite_banner(int sock)
 {
-   write(sock, "\0\0\xfa\xda\0\x02", 6);  
+   write(sock, "\0\0\xfa\xda\0\x02", 6);
+}
+
+void cisco_sccp_banner(int sock)
+{
+   stream_write(sock, "SCCP Cisco CallManager 12.0\r\n");
+}
+
+void cisco_smi_banner(int sock)
+{
+   unsigned char msg[] = {0x00,0x00,0x00,0x04,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x04,0x00,0x00,0x00,0x04,0x00,0x00,0x00,0x01};
+   write(sock, msg, sizeof(msg));
+}
+
+void cisco_sip_banner(int sock)
+{
+   stream_write(sock, "SIP/2.0 200 OK\r\nServer: Cisco-SIPGateway\r\n\r\n");
+}
+
+void cisco_tftp_banner(int sock)
+{
+   unsigned char msg[] = {0x00,0x05,0x00,0x00,'I','n','v','a','l','i','d',' ','T','F','T','P',' ','O','p','c','o','d','e'};
+   write(sock, msg, sizeof(msg));
+}
+
+void cisco_snmp_banner(int sock)
+{
+   stream_write(sock, "SNMPv2-MIB::sysDescr.0 = STRING: Cisco IOS Software\r\n");
+}
+
+void cisco_ike_banner(int sock)
+{
+   stream_write(sock, "Cisco VPN 3000 concentrator\r\n");
+}
+
+void ms_ldap_gc_banner(int sock)
+{
+   stream_write(sock, "Active Directory LDAP\r\n");
+}
+
+void ms_rpc_dynamic_banner(int sock)
+{
+   stream_write(sock, "Microsoft Windows RPC\r\n");
+}
+
+void apple_ard_banner(int sock)
+{
+   stream_write(sock, "ARDAgent\r\n");
+}
+
+void apple_daap_banner(int sock)
+{
+   stream_write(sock, "HTTP/1.1 200 OK\r\nServer: DAAP\r\n\r\n");
+}
+
+void ibm_mqtt_tls_banner(int sock)
+{
+   stream_write(sock, "IBM MessageSight MQTT\r\n");
+}
+
+void vmware_vami_banner(int sock)
+{
+   stream_write(sock, "HTTP/1.1 200 OK\r\nServer: VMware VAMI\r\n\r\n");
 }
 
 int telnet_password_prompt(char *line, struct conn_state *state, int max_tries)
@@ -136,6 +198,54 @@ void handle_connection (int sock)
    } else if (strcmp(var_type, "cisco-lm") == 0) {
       cisco_lm6_banner(sock);
       sleep(2);
+
+   } else if (strcmp(var_type, "cisco-sccp") == 0) {
+      cisco_sccp_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "cisco-smi") == 0) {
+      cisco_smi_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "cisco-sip") == 0) {
+      cisco_sip_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "cisco-tftp") == 0) {
+      cisco_tftp_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "cisco-snmp") == 0) {
+      cisco_snmp_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "cisco-ike") == 0) {
+      cisco_ike_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "ms-ldap-gc") == 0) {
+      ms_ldap_gc_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "ms-rpc-dynamic") == 0) {
+      ms_rpc_dynamic_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "apple-ard") == 0) {
+      apple_ard_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "apple-daap") == 0) {
+      apple_daap_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "ibm-mqtt-tls") == 0) {
+      ibm_mqtt_tls_banner(sock);
+      sleep(1);
+
+   } else if (strcmp(var_type, "vmware-vami") == 0) {
+      vmware_vami_banner(sock);
+      sleep(1);
 
    } else {
       die_err("Unsupported mode: %s", var_type);

--- a/src/honeybee.c
+++ b/src/honeybee.c
@@ -134,15 +134,27 @@ void print_help(char *self)
    printf("Usage : %s [ -a | -m <mode> ] [ -dhpv ]\n", self);
    printf("\t-a starts daemons for all modes\n");
    printf("\t-d goes daemon\n\t-h prints this help\n");
-   printf("\t-m sets honeypot mode, available modes - with name and port:\n", var_type);
+   printf("\t-m sets honeypot mode, available modes - with name and port:\n");
    printf("\t\tcisco-fingerd\t\tCisco fingerd\t\t\t\t2003\n");
    printf("\t\tcisco-telnet-fire\tCisco PIX 500 series telnetd\t\t5999\n");
    printf("\t\tcisco-telnet-fire2\tCisco telnetd (IOS 6.X)\t\t\t5998\n");
    printf("\t\tcisco-http-fire\t\tCisco ASA firewall http config\t\t5911\n");
    printf("\t\tcisco-lm\t\tCisco CallManager license manager 6\t5910\n");
+   printf("\t\tcisco-sccp\t\tCisco CallManager SCCP v12\t\t2000\n");
+   printf("\t\tcisco-smi\t\tCisco Smart Install Client\t\t4786\n");
+   printf("\t\tcisco-sip\t\tCisco SIP Gateway\t\t\t5060\n");
+   printf("\t\tcisco-tftp\t\tCisco TFTP server\t\t\t69\n");
+   printf("\t\tcisco-snmp\t\tCisco SNMP agent\t\t\t161\n");
+   printf("\t\tcisco-ike\t\tCisco VPN 3000 concentrator\t500\n");
+   printf("\t\tms-ldap-gc\t\tActive Directory LDAP\t\t3268\n");
+   printf("\t\tms-rpc-dynamic\tMicrosoft Windows RPC\t\t49152\n");
+   printf("\t\tapple-ard\t\tApple ARD agent\t\t\t5555\n");
+   printf("\t\tapple-daap\t\tApple iTunes DAAP sharing\t3689\n");
+   printf("\t\tibm-mqtt-tls\t\tIBM MessageSight MQTT\t\t8883\n");
+   printf("\t\tvmware-vami\t\tVMware vCenter VAMI\t\t9443\n");
    printf("\t\toracle-app-manager\tOracle Application Server 11g httpd\t5988\n");
    printf("\t\toracle-rmi-lite\t\tOracle Database Lite RMI\t\t5987\n");
-   printf("\t-p force specific port number (defaults according to module)\n", var_port);
+   printf("\t-p force specific port number (defaults according to module)\n");
    printf("\t-v enters verbose (debug) mode (currently %s)\n\n", 
       var_debug ? "ON" : "OFF");
 }
@@ -171,6 +183,42 @@ int get_port_for_type(char *honey_type)
    } else if (strcmp(honey_type, "cisco-lm") == 0) {
       return 5910;
 
+   } else if (strcmp(honey_type, "cisco-sccp") == 0) {
+      return 2000;
+
+   } else if (strcmp(honey_type, "cisco-smi") == 0) {
+      return 4786;
+
+   } else if (strcmp(honey_type, "cisco-sip") == 0) {
+      return 5060;
+
+   } else if (strcmp(honey_type, "cisco-tftp") == 0) {
+      return 69;
+
+   } else if (strcmp(honey_type, "cisco-snmp") == 0) {
+      return 161;
+
+   } else if (strcmp(honey_type, "cisco-ike") == 0) {
+      return 500;
+
+   } else if (strcmp(honey_type, "ms-ldap-gc") == 0) {
+      return 3268;
+
+   } else if (strcmp(honey_type, "ms-rpc-dynamic") == 0) {
+      return 49152;
+
+   } else if (strcmp(honey_type, "apple-ard") == 0) {
+      return 5555;
+
+   } else if (strcmp(honey_type, "apple-daap") == 0) {
+      return 3689;
+
+   } else if (strcmp(honey_type, "ibm-mqtt-tls") == 0) {
+      return 8883;
+
+   } else if (strcmp(honey_type, "vmware-vami") == 0) {
+      return 9443;
+
    } else {
       die_err("Unsupported mode: %s", honey_type);
    }
@@ -185,6 +233,18 @@ void init_modes()
    modes[ORACLE_RMI_LITE]     = ORACLE_RMI_LITE_S;
    modes[ORACLE_APP_MANAGER]  = ORACLE_APP_MANAGER_S;
    modes[CISCO_LM]            = CISCO_LM_S;
+   modes[CISCO_SCCP]          = CISCO_SCCP_S;
+   modes[CISCO_SMI]           = CISCO_SMI_S;
+   modes[CISCO_SIP]           = CISCO_SIP_S;
+   modes[CISCO_TFTP]          = CISCO_TFTP_S;
+   modes[CISCO_SNMP]          = CISCO_SNMP_S;
+   modes[CISCO_IKE]           = CISCO_IKE_S;
+   modes[MS_LDAP_GC]          = MS_LDAP_GC_S;
+   modes[MS_RPC_DYNAMIC]      = MS_RPC_DYNAMIC_S;
+   modes[APPLE_ARD]           = APPLE_ARD_S;
+   modes[APPLE_DAAP]          = APPLE_DAAP_S;
+   modes[IBM_MQTT_TLS]        = IBM_MQTT_TLS_S;
+   modes[VMWARE_VAMI]         = VMWARE_VAMI_S;
 }
 
 

--- a/src/honeybee.h
+++ b/src/honeybee.h
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #define APP_NAME "HoneyBee"
-#define APP_VERSION "0.192"
+#define APP_VERSION "0.193"
 #define BUF_SZ 1024
 
 #define CISCO_TELNET_FIRE_S   "cisco-telnet-fire"
@@ -13,6 +13,18 @@
 #define ORACLE_RMI_LITE_S     "oracle-rmi-lite"
 #define ORACLE_APP_MANAGER_S  "oracle-app-manager"
 #define CISCO_LM_S            "cisco-lm"
+#define CISCO_SCCP_S          "cisco-sccp"
+#define CISCO_SMI_S           "cisco-smi"
+#define CISCO_SIP_S           "cisco-sip"
+#define CISCO_TFTP_S          "cisco-tftp"
+#define CISCO_SNMP_S          "cisco-snmp"
+#define CISCO_IKE_S           "cisco-ike"
+#define MS_LDAP_GC_S          "ms-ldap-gc"
+#define MS_RPC_DYNAMIC_S      "ms-rpc-dynamic"
+#define APPLE_ARD_S           "apple-ard"
+#define APPLE_DAAP_S          "apple-daap"
+#define IBM_MQTT_TLS_S        "ibm-mqtt-tls"
+#define VMWARE_VAMI_S         "vmware-vami"
 
 #define CISCO_TELNET_FIRE     0
 #define CISCO_TELNET_FIRE2    1
@@ -21,8 +33,20 @@
 #define ORACLE_RMI_LITE       4
 #define ORACLE_APP_MANAGER    5
 #define CISCO_LM              6
+#define CISCO_SCCP            7
+#define CISCO_SMI             8
+#define CISCO_SIP             9
+#define CISCO_TFTP            10
+#define CISCO_SNMP            11
+#define CISCO_IKE             12
+#define MS_LDAP_GC            13
+#define MS_RPC_DYNAMIC        14
+#define APPLE_ARD             15
+#define APPLE_DAAP            16
+#define IBM_MQTT_TLS          17
+#define VMWARE_VAMI           18
 
-#define MODE_COUNT            7
+#define MODE_COUNT            19
 
 extern int var_port;
 extern int var_debug;


### PR DESCRIPTION
## Summary
- add new service banners for multiple Cisco, Microsoft, Apple and other products
- expose new modes via command line help
- extend mode list and default ports
- document the full set of simulated services

## Testing
- `make`
- `./honeybee -h`

------
https://chatgpt.com/codex/tasks/task_e_6862ef779a0c832dab9d875bea9fb4ba